### PR TITLE
returning totalSize to getOfferDetails

### DIFF
--- a/src/Settlement.sol
+++ b/src/Settlement.sol
@@ -278,7 +278,8 @@ contract Settlement is EIP712 {
             address,
             address,
             uint128,
-            uint128
+            uint128,
+            uint256
         )
     {
         OfferData memory offer = _offers[_offerId];
@@ -288,7 +289,8 @@ contract Settlement is EIP712 {
             offer.offerToken,
             offer.bidToken,
             offer.minPrice,
-            offer.minBidSize
+            offer.minBidSize,
+            offer.totalSize
         );
     }
 

--- a/test/SettlementTest.t.sol
+++ b/test/SettlementTest.t.sol
@@ -53,13 +53,14 @@ contract SettlementTest is Test {
 
     function testCreateOffer() public {
         uint256 offerId = _createOffer(seller, address(squeeth), address(usdc), uint128(1000e6), uint128(1), 100);
-        (address sellerAddr, address offerToken, address bidToken, uint128 minPrice, uint128 minBidSize) = settlement.getOfferDetails(offerId);
+        (address sellerAddr, address offerToken, address bidToken, uint128 minPrice, uint128 minBidSize, uint256 totalSize) = settlement.getOfferDetails(offerId);
 
         assertEq(sellerAddr, seller);
         assertEq(offerToken, address(squeeth));
         assertEq(bidToken, address(usdc));
         assertEq(minPrice, uint128(1000e6));
         assertEq(minBidSize, uint128(1));
+        assertEq(totalSize, uint256(100));
     }
 
     function testSettleOffer() public {

--- a/test/e2e/SettlementTestFork.t.sol
+++ b/test/e2e/SettlementTestFork.t.sol
@@ -56,13 +56,14 @@ contract SettlementTestFork is Test {
 
     function testCreateOffer() public {
         uint256 offerId = _createOffer(seller, address(squeeth), address(usdc), uint128(1000e6), uint128(1), 100);
-        (address sellerAddr, address offerToken, address bidToken, uint128 minPrice, uint128 minBidSize) = settlement.getOfferDetails(offerId);
+        (address sellerAddr, address offerToken, address bidToken, uint128 minPrice, uint128 minBidSize, uint256 totalSize) = settlement.getOfferDetails(offerId);
 
         assertEq(sellerAddr, seller);
         assertEq(offerToken, address(squeeth));
         assertEq(bidToken, address(usdc));
         assertEq(minPrice, uint128(1000e6));
         assertEq(minBidSize, uint128(1));
+        assertEq(totalSize, uint256(100));
     }
 
     function testGetBidSigner() public {        


### PR DESCRIPTION
paradigmco server is validating totalSize before it creates an RFQ on their system.
Currently SDK uses getOfferDetails on the contract to return the offer into to the paradigmco server
making the contract return the field so that we can send that to paradigmco server as part of SDK
